### PR TITLE
fix: keep sent status durable when an email_sent receiver fails

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -414,7 +414,20 @@ def _send_bulk(
     email_ids = [email.id for email in sent_emails]
     Email.objects.filter(id__in=email_ids).update(status=STATUS.sent, last_updated=timezone.now())
     if sent_emails:
-        email_sent.send(sender=Email, emails=sent_emails)
+        # send_queued() wraps this whole batch in a single transaction so the
+        # select_for_update locks are held for the duration. A receiver that
+        # raises would propagate out of that transaction and roll back the
+        # status=sent update above, leaving the (already delivered) emails
+        # queued -> they get re-sent on the next run. Use send_robust so a
+        # broken receiver can never revert a successful delivery; log instead.
+        for receiver, response in email_sent.send_robust(sender=Email, emails=sent_emails):
+            if isinstance(response, Exception):
+                logger.error(
+                    'email_sent receiver %r failed after successful delivery; '
+                    'sent status preserved to prevent re-send',
+                    receiver,
+                    exc_info=response,
+                )
 
     # Update statuses and conditionally requeue failed emails
     num_failed, num_requeued = 0, 0

--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -423,8 +423,7 @@ def _send_bulk(
         for receiver, response in email_sent.send_robust(sender=Email, emails=sent_emails):
             if isinstance(response, Exception):
                 logger.error(
-                    'email_sent receiver %r failed after successful delivery; '
-                    'sent status preserved to prevent re-send',
+                    'email_sent receiver %r failed after successful delivery; sent status preserved to prevent re-send',
                     receiver,
                     exc_info=response,
                 )

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -248,7 +248,19 @@ class Email(models.Model):
                 self.logs.create(status=status, message=message, exception_type=exception_type)
 
             if status == STATUS.sent:
-                email_sent.send(sender=Email, emails=[self])
+                # status was already saved above; use send_robust so a failing
+                # receiver can't propagate and (inside an outer transaction)
+                # roll back that save -> which would re-send an already-sent
+                # email. Log receiver failures instead.
+                for receiver, response in email_sent.send_robust(sender=Email, emails=[self]):
+                    if isinstance(response, Exception):
+                        logger.error(
+                            'email_sent receiver %r failed after successful delivery '
+                            'of email #%d; sent status preserved to prevent re-send',
+                            receiver,
+                            self.id,
+                            exc_info=response,
+                        )
         return status
 
     def clean(self):

--- a/post_office/version.py
+++ b/post_office/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.10.1.post2'
+VERSION = '3.10.1.post3'

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 
 from post_office.mail import _send_bulk, attach_templates, create, get_queued, send, send_many, send_queued
 from post_office.models import PRIORITY, STATUS, Attachment, Email, EmailTemplate
+from post_office.signals import email_sent
 from post_office.settings import (
     get_batch_size,
     get_log_level,
@@ -619,11 +620,12 @@ class MailTest(TransactionTestCase):
         self.assertTrue(qs.query.select_for_update_skip_locked)
 
     @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
-    @patch('post_office.signals.email_sent.send')
+    @patch('post_office.signals.email_sent.send_robust')
     def test_email_sent_signal_on_bulk_send(self, mock_signal):
         """
         Ensure email_sent signal fires after _send_bulk successfully sends emails.
         """
+        mock_signal.return_value = []
         email = Email.objects.create(
             to=['to@example.com'],
             from_email='bob@example.com',
@@ -640,7 +642,7 @@ class MailTest(TransactionTestCase):
         self.assertEqual(len(sent_emails), 1)
         self.assertEqual(sent_emails[0].id, email.id)
 
-    @patch('post_office.signals.email_sent.send')
+    @patch('post_office.signals.email_sent.send_robust')
     def test_email_sent_signal_not_fired_on_bulk_failure(self, mock_signal):
         """
         Ensure email_sent signal does NOT fire when all emails fail in _send_bulk.
@@ -655,6 +657,38 @@ class MailTest(TransactionTestCase):
         )
         _send_bulk([email], uses_multiprocessing=False)
         mock_signal.assert_not_called()
+
+    @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+    def test_sent_status_survives_failing_email_sent_receiver(self):
+        """
+        Regression: a receiver raising must NOT roll back the status=sent update
+        inside send_queued's transaction. Otherwise the (already delivered)
+        email stays queued and is re-sent on the next run. send_robust must
+        swallow the receiver error and keep the sent status durable.
+        """
+        email = Email.objects.create(
+            to=['to@example.com'],
+            from_email='bob@example.com',
+            subject='Test robust',
+            message='Message',
+            status=STATUS.queued,
+            backend_alias='locmem',
+        )
+
+        def boom(sender, **kwargs):
+            raise ValueError('receiver intentionally fails')
+
+        email_sent.connect(boom, sender=Email)
+        try:
+            # must not raise despite the failing receiver
+            total_sent, total_failed, total_requeued = send_queued()
+        finally:
+            email_sent.disconnect(boom, sender=Email)
+
+        self.assertEqual(total_sent, 1)
+        email.refresh_from_db()
+        self.assertEqual(email.status, STATUS.sent)
+        self.assertEqual(Email.objects.filter(status=STATUS.queued).count(), 0)
 
     @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
     def test_send_queued_within_transaction(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -370,11 +370,12 @@ class ModelTest(TestCase):
         list(deserialized_objects)[0].save()
         self.assertEqual(EmailTemplate.objects.count(), 1)
 
-    @patch('post_office.signals.email_sent.send')
+    @patch('post_office.signals.email_sent.send_robust')
     def test_dispatch_email_sent_signal_on_success(self, mock_signal):
         """
         Ensure email_sent signal fires only when dispatch succeeds.
         """
+        mock_signal.return_value = []
         email = Email.objects.create(
             to=['to@example.com'],
             from_email='from@example.com',
@@ -385,7 +386,7 @@ class ModelTest(TestCase):
         email.dispatch()
         mock_signal.assert_called_once_with(sender=Email, emails=[email])
 
-    @patch('post_office.signals.email_sent.send')
+    @patch('post_office.signals.email_sent.send_robust')
     def test_dispatch_email_sent_signal_not_on_failure(self, mock_signal):
         """
         Ensure email_sent signal does NOT fire when dispatch fails.


### PR DESCRIPTION
## Summary
`send_queued()` holds the whole batch in a single transaction (needed for `select_for_update`), so a receiver raising in the `email_sent` signal propagated out and **rolled back the `status=sent` update** — already-delivered emails stayed `queued` and were re-sent on the next run.

Dispatch `email_sent` via `send_robust` at both call sites (`_send_bulk` and `Email.dispatch`) and log any receiver failure, so a broken receiver can never revert a confirmed send. The signal only ever fires for genuinely-sent emails (`sent_emails` / `if status == STATUS.sent`), so preserving `sent` is correct; send failures are unaffected (they still route to `failed`/`requeued`).

Bumps version to `3.10.1.post3`.

## Test plan
- [x] New `tests/test_mail.py::test_sent_status_survives_failing_email_sent_receiver` — fails on old `.send` code (receiver `ValueError` escapes `send_queued`), passes with `send_robust`.
- [x] Updated the 3 existing `email_sent` tests to patch `send_robust`.
- [x] `tests/test_mail.py` + `tests/test_models.py` — 56 passed.